### PR TITLE
change react and react-dom to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,6 @@
   },
   "author": "Ryan Valentin",
   "license": "MIT",
-  "dependencies": {
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1"
-  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.24.0",
@@ -35,8 +31,14 @@
     "babel-preset-react": "^6.23.0",
     "eslint": "^3.19.0",
     "eslint-plugin-react": "^6.10.3",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1",
     "uglify-js": "^3.1.2",
     "webpack": "^2.3.2",
     "webpack-dev-server": "^2.4.2"
+  },
+  "peerDependencies": {
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
   }
 }


### PR DESCRIPTION
Hello! I have a project that uses React 16. I'd like to use this component, and when I do so, it adds React 15 into my `yarn.lock` and causes an extra version of React to be downloaded.

The peer dependency pattern allows downstream projects to use this library without installing an extra version of `react` and `react-dom`.

Here are some other published react components that use `peerDependencies`:
- https://github.com/tomchentw/react-google-maps/blob/master/package.json#L119
- https://github.com/reactjs/react-autocomplete/blob/master/package.json#L80