### PR TITLE
Component Should Update not working without `identifier`

### DIFF
--- a/src/CommentCount.jsx
+++ b/src/CommentCount.jsx
@@ -17,7 +17,7 @@ export class CommentCount extends React.Component {
 
         const nextConfig = nextProps.config;
         const config = this.props.config;
-        if (nextConfig.url === config.url || nextConfig.identifier === config.identifier)
+        if (nextConfig.url === config.url && nextConfig.identifier === config.identifier)
             return false;
         return true;
     }

--- a/src/DiscussionEmbed.jsx
+++ b/src/DiscussionEmbed.jsx
@@ -17,7 +17,7 @@ export class DiscussionEmbed extends React.Component {
 
         const nextConfig = nextProps.config;
         const config = this.props.config;
-        if (nextConfig.url === config.url || nextConfig.identifier === config.identifier)
+        if (nextConfig.url === config.url && nextConfig.identifier === config.identifier)
             return false;
         return true;
     }


### PR DESCRIPTION
if `nextConfig.identifier` and `config.identifier` are `undefined` and you are changing the `url` config, the component should update.

Currently, if you are not using ids but only URLs to reference discussions, `config.identifier`, will always be `undefined`, hence the condition:

```javascript
        if (nextConfig.url === config.url || nextConfig.identifier === config.identifier)
            return false;
```

Will be evaluated as true in the second branch and the all over component will not update.

In a current application i am working on, when i change page, the discuss thread is not updated as a consequence of this bug