### PR TITLE
#25 Check for id before adding script

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,6 @@
 export function insertScript(src, id, parentElement) {
+    if (window.document.getElementById(id))
+        return;
     const script = window.document.createElement('script');
     script.async = true;
     script.src = src;


### PR DESCRIPTION
This is to avoid a script being loaded twice in the page (see #25 )