### PR TITLE
Add React 16 support to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "author": "Ryan Valentin",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+    "react": "^15.6.1 || ^16.0.0",
+    "react-dom": "^15.6.1 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
## Description  
Added `^16.0.0` to `react` and `react-dom` peerDependencies

## Motivation and Context  
React 16 support should be reflected in the peerDependencies

## How Has This Been Tested?  
Tested package with React v16.8.6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/disqus/disqus-react/27)
<!-- Reviewable:end -->
