### PR TITLE
Add GitHub issue and pull-request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us address an issue
+---
+
+### Describe the bug  
+A clear and concise description of what the bug is.  
+
+### To Reproduce  
+Steps to reproduce the behavior:  
+  1. Go to '...'  
+  2. Click on '....'  
+  3. Scroll down to '....'  
+  4. See error  
+
+### Expected behavior  
+A clear and concise description of what you expected to happen.  
+
+### Screenshots  
+If applicable, add screenshots to help explain your problem.  
+
+### Specifications:  
+ - OS: 
+ - Package version: 
+ - Node version: 
+
+### Additional context  
+Add any other context about the problem here.  

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest an idea for this package
+---
+
+### Is your feature request related to a problem? Please describe.  
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]  
+
+### Describe the solution you'd like  
+A clear and concise description of what you want to happen.  
+
+### Describe alternatives you've considered  
+A clear and concise description of any alternative solutions or features you've considered.  
+
+### Additional context  
+Add any other context or screenshots about the feature request here.  

--- a/.github/ISSUE_TEMPLATE/question_template.md
+++ b/.github/ISSUE_TEMPLATE/question_template.md
@@ -1,5 +1,5 @@
 ---
-name: Question template
+name: Question
 about: Ask a question about the package
 ---
 

--- a/.github/ISSUE_TEMPLATE/question_template.md
+++ b/.github/ISSUE_TEMPLATE/question_template.md
@@ -1,0 +1,5 @@
+---
+name: Question template
+about: Ask a question about the package
+---
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description  
+<!--- Describe your changes in detail -->
+
+## Motivation and Context  
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?  
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):  
+
+## Types of changes  
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)  
+- [ ] New feature (non-breaking change which adds functionality)  
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
+
+## Checklist:  
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.  
+- [ ] My change requires a change to the documentation.  
+  - [ ] I have updated the documentation accordingly.   
+- [ ] All new and existing tests passed.  


### PR DESCRIPTION
## Description
Added issue and pull-request templates to make both much easier to manage and lets contributors know the information that we will need to address their issue or merge their PR.  
Issue templates also separate issues into **Bug Report**, **Feature Request**, **Question**, making them easier to identify and address.


## Motivation and Context  
There are a handful of issues and PR's of varying quality and requesting additional information from contributors can be timely and inconsistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/disqus/disqus-react/28)
<!-- Reviewable:end -->
