### PR TITLE
Add callbacks support

### DIFF
--- a/src/DiscussionEmbed.jsx
+++ b/src/DiscussionEmbed.jsx
@@ -2,6 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { insertScript, removeScript, shallowComparison } from './utils';
 
+const callbacks = [
+    'preData',
+    'preInit',
+    'onInit',
+    'onReady',
+    'afterRender',
+    'preReset',
+    'onIdentify',
+    'beforeComment',
+    'onNewComment',
+    'onPaginate',
+];
+
 export class DiscussionEmbed extends React.Component {
 
     componentDidMount() {
@@ -60,9 +73,12 @@ export class DiscussionEmbed extends React.Component {
             this.page.identifier = config.identifier;
             this.page.url = config.url;
             this.page.title = config.title;
-            this.callbacks.onNewComment = [
-                config.onNewComment,
-            ];
+
+            callbacks.forEach(callbackName => {
+                this.callbacks[callbackName] = [
+                    config[callbackName],
+                ];
+            });
         };
     }
 
@@ -79,6 +95,15 @@ DiscussionEmbed.propTypes = {
         identifier: PropTypes.string,
         url: PropTypes.string,
         title: PropTypes.string,
+        preData: PropTypes.func,
+        preInit: PropTypes.func,
+        onInit: PropTypes.func,
+        onReady: PropTypes.func,
+        afterRender: PropTypes.func,
+        preReset: PropTypes.func,
+        onIdentify: PropTypes.func,
+        beforeComment: PropTypes.func,
         onNewComment: PropTypes.func,
+        onPaginate: PropTypes.func,
     }).isRequired,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added support for built-in Disqus callbacks.

## Motivation and Context  
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently this module support only `onNewComment` callback, however more callbacks are available in Disqus. This is the full list of callbacks found in Disqus `embed.js` script:
- preData
- preInit
- onInit
- onReady
- afterRender
- preReset
- onIdentify
- beforeComment
- onNewComment
- onPaginate

After a few tests I've found that actually only `onNewComment` and `onReady` are firing, maybe the rest are reserved for the future.

This PR fixes #61.

## How Has This Been Tested?  
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I built the package and tested it on my own website.

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.  
- [x] My change requires a change to the documentation.  
  - [ ] I have updated the documentation accordingly.   
- [x] All new and existing tests passed.  
