### PR TITLE
Pass rest props to DiscussionEmbed component.

### DIFF
--- a/src/DiscussionEmbed.jsx
+++ b/src/DiscussionEmbed.jsx
@@ -68,7 +68,7 @@ export class DiscussionEmbed extends React.Component {
 
     render() {
         return (
-            <div id="disqus_thread"></div>
+            <div {...this.props} id="disqus_thread"></div>
         );
     }
 }


### PR DESCRIPTION
## Description  
Pass rest props to DiscussionEmbed component.

## Motivation and Context  
Additional props can be added into DiscussionEmbed component. e.g.: `props.children`, `props.className`. but `props.id` will be ignored.

```jsx
<Disqus.DiscussionEmbed 
  shortname="abc" 
  config={{}} 
  className="hello world" // added into div#disqus_thread tag.
  id="hmm..." // ignored.
>
  Loading... (Loading text, image or something else can be added!)
</Disqus.DiscussionEmbed>
```

## How Has This Been Tested?  
Not tested. However, there are no bug-prone changes and maybe there is no need for testing.

## Types of changes  
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have updated the documentation accordingly.   
- [ ] All new and existing tests passed.  
