### PR TITLE
Fix README config prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ import { DiscussionEmbed } from 'disqus-react';
 <DiscussionEmbed
     shortname='example'
     config={
-        url: this.props.article.url,
-        identifier: this.props.article.id,
-        title: this.props.article.title,
+        {
+            url: this.props.article.url,
+            identifier: this.props.article.id,
+            title: this.props.article.title,
+        }
     }
 />
 ```
@@ -49,9 +51,11 @@ import { CommentCount } from 'disqus-react';
 <Disqus.CommentCount
     shortname='example'
     config={
-        url: this.props.article.url,
-        identifier: this.props.article.id,
-        title: this.props.article.title,
+        {
+            url: this.props.article.url,
+            identifier: this.props.article.id,
+            title: this.props.article.title,
+        }
     }
 >
     {/* Placeholder Text */}


### PR DESCRIPTION
Config prop needs to have an object of `url` `identifier` and `title` where right now it's just passing those values directly to the prop without it as an object.
<!--- Provide a general summary of your changes in the Title above -->

## Description  
<!--- Describe your changes in detail -->

## Motivation and Context  
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?  
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):  

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.  
- [x] My change requires a change to the documentation.  
  - [x] I have updated the documentation accordingly.   
- [ ] All new and existing tests passed.  
