### PR TITLE
Add language configuration support for DiscussionEmbed component

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,22 @@ import { DiscussionEmbed } from 'disqus-react';
             url: this.props.article.url,
             identifier: this.props.article.id,
             title: this.props.article.title,
+            language: 'zh_TW' //e.g. for Traditional Chinese (Taiwan)	
         }
     }
 />
 ```
 
 This component is limited to one instance in the DOM at a time and will handle updates to both the `config` and `shortname` props and reload appropriately with the new discussion thread.  
+
+#### `language` configuration
+
+This configuration overrides will load the Disqus embed in different languages on a per-page basis.
+
+- Language code can be found on: https://www.transifex.com/explore/languages/ 
+- The supported languages by disqus are available on https://www.transifex.com/disqus/disqus/
+
+> Note: Depending on the completeness of the translation for a given language, and the release of language support from disqus, the strings displayed on discussion thread UI may not be completely translated.
 
 
 ### CommentCount  

--- a/README.md
+++ b/README.md
@@ -41,15 +41,6 @@ import { DiscussionEmbed } from 'disqus-react';
 
 This component is limited to one instance in the DOM at a time and will handle updates to both the `config` and `shortname` props and reload appropriately with the new discussion thread.  
 
-#### `language` configuration
-
-This configuration overrides will load the Disqus embed in different languages on a per-page basis.
-
-- Language code can be found on: https://www.transifex.com/explore/languages/ 
-- The supported languages by disqus are available on https://www.transifex.com/disqus/disqus/
-
-> Note: Depending on the completeness of the translation for a given language, and the release of language support from disqus, the strings displayed on discussion thread UI may not be completely translated.
-
 
 ### CommentCount  
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "disqus-react",
-  "version": "1.0.9",
+  "version": "1.0.8",
   "description": "Official React components to embed Disqus discussions and comments.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "disqus-react",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Official React components to embed Disqus discussions and comments.",
   "repository": {
     "type": "git",

--- a/src/DiscussionEmbed.jsx
+++ b/src/DiscussionEmbed.jsx
@@ -99,6 +99,7 @@ DiscussionEmbed.propTypes = {
         identifier: PropTypes.string,
         url: PropTypes.string,
         title: PropTypes.string,
+        language: PropTypes.string,
         preData: PropTypes.func,
         preInit: PropTypes.func,
         onInit: PropTypes.func,

--- a/src/DiscussionEmbed.jsx
+++ b/src/DiscussionEmbed.jsx
@@ -75,6 +75,8 @@ export class DiscussionEmbed extends React.Component {
             this.page.title = config.title;
             this.page.remote_auth_s3 = config.remoteAuthS3;
             this.page.api_key = config.apiKey;
+            if (config.language)
+                this.language = config.language;
 
             callbacks.forEach(callbackName => {
                 this.callbacks[callbackName] = [

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,6 +6,7 @@ interface DisqusProps {
     url: string;
     identifier: string;
     title: string;
+    language: string;
   };
 }
 


### PR DESCRIPTION
## Description  
Add language configuration support for DiscussionEmbed component

> Note: Depending on the completeness of the translation for a given language, and the release of language support from disqus, the strings displayed on discussion thread UI may not be completely translated.

## Motivation and Context  
This is an attempt to address the requirement raised on https://github.com/disqus/disqus-react/issues/12

## How Has This Been Tested?  
Tested with the Gatsby production web site on https://thefabulouslifestyles.com/ 

## Screenshots (if appropriate):  

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
~~- [ ] Bug fix (non-breaking change which fixes an issue)~~
- [X] New feature (non-breaking change which adds functionality)  

~~- [ ] Breaking change (fix or feature that would cause existing functionality to change)~~

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.  
- [X] My change requires a change to the documentation.  
  - [X] I have updated the documentation accordingly.   
