### PR TITLE
Prevent false-positives in `shallowComparison` function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -53,8 +53,12 @@ export function shallowComparison(currentProps, nextProps) {
     // Perform a comparison of all props, excluding React Elements, to prevent unnecessary updates
     const propNames = new Set(Object.keys(currentProps), Object.keys(nextProps)); // eslint-disable-line no-undef
     for (const name of propNames) {
-        if (currentProps[name] !== nextProps[name] && !isReactElement(currentProps[name]))
+        if (typeof currentProps[name] === 'object') {
+            if (shallowComparison(currentProps[name], nextProps[name]))
+                return true;
+        } else if (currentProps[name] !== nextProps[name] && !isReactElement(currentProps[name])) {
             return true;
+        }
     }
     return false;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description  
<!--- Describe your changes in detail -->
There was a bug in the `shallowComparison` function that determines whether the components should update that was causing the components to update anytime the parent component was re-rendered. This was due to the fact that when passed props that contained objects, the function was comparing the objects directly rather than comparing their individual attributes.

## Motivation and Context  
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #74 

## How Has This Been Tested?  
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on a local test site.

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.   
- [x] All new and existing tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/disqus/disqus-react/75)
<!-- Reviewable:end -->
