### PR TITLE
Fix typing issue

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,7 +27,7 @@ interface DiscussionEmbedProps {
   config: DiscussionEmbedConfig;
 };
 
-interface CommentCountProps extends DisqusProps {
+interface CommentCountProps extends DiscussionEmbedProps {
   shortname: string,
   config: DisqusConfig;
   children?: React.ReactNode;


### PR DESCRIPTION
## Description  
DisqusProps were renamed to DiscussionEmbedProps but the extension was not changed. This causes a build break when using this with yarn

## Motivation and Context  
This issue causes a build break when using yarn,  gatsbyjs + typescript

## Screenshots (if appropriate):  

## Types of changes  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
- [x] My code follows the code style of this project.  
- [x] My change requires a change to the documentation.  
  - [x] I have updated the documentation accordingly.   
- [x] All new and existing tests passed.  
