### PR TITLE
Add React 17.x as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "author": "Ryan Valentin",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^15.6.1 || ^16.0.0",
-    "react-dom": "^15.6.1 || ^16.0.0"
+    "react": "^15.6.1 || ^16.0.0 || ^17.0.0",
+    "react-dom": "^15.6.1 || ^16.0.0 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
## Description  

Disqus React seems to perfectly support React 17.x.
Also see https://github.com/disqus/disqus-react/issues/87.

## Motivation and Context  

This removes a warning on npm/yarn install regarding incorrect peer dependencies when running on React 17.

## How Has This Been Tested?  

This is tested on my personal blog by rendering disqus comments on my blogposts. See the end of this blog.

https://nextjs-blog-git-disqus.marcofranssen.vercel.app/blog/remove-files-from-git-history-using-git-filter-repo

## Screenshots (if appropriate):  

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have updated the documentation accordingly.   
- [x] All new and existing tests passed.  
