### PR TITLE
Add type definitions for Recommendations component

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,7 +4,7 @@ interface DisqusConfig {
   url?: string;
   identifier?: string;
   title?: string;
-};
+}
 
 interface DiscussionEmbedConfig extends DisqusConfig {
   categoryID?: string;
@@ -20,18 +20,18 @@ interface DiscussionEmbedConfig extends DisqusConfig {
   beforeComment?: (...args: any[]) => any;
   onNewComment?: (...args: any[]) => any;
   onPaginate?: (...args: any[]) => any;
-};
+}
 
 interface DiscussionEmbedProps {
   shortname: string;
   config: DiscussionEmbedConfig;
-};
+}
 
 interface CommentCountProps extends DiscussionEmbedProps {
-  shortname: string,
+  shortname: string;
   config: DisqusConfig;
   children?: React.ReactNode;
-};
+}
 
 interface CommentEmbedProps {
   commentId: string;
@@ -39,22 +39,17 @@ interface CommentEmbedProps {
   showMedia?: boolean;
   width?: number;
   height?: number;
-};
-
-interface IDisqus {
-  CommentCount: React.Component<CommentCountProps, {}>;
-  CommentEmbed: React.Component<CommentEmbedProps, {}>;
-  DiscussionEmbed: React.Component<DiscussionEmbedProps, {}>;
-};
+}
 
 declare class CommentCount extends React.Component<CommentCountProps, {}> {}
 declare class CommentEmbed extends React.Component<CommentEmbedProps, {}> {}
 declare class DiscussionEmbed extends React.Component<DiscussionEmbedProps, {}> {}
+
 declare const Disqus: {
   CommentCount: React.ComponentType<CommentCountProps>;
   CommentEmbed: React.ComponentType<CommentEmbedProps>;
   DiscussionEmbed: React.ComponentType<DiscussionEmbedProps>;
-};
+}
 
 export { CommentCount, CommentEmbed, DiscussionEmbed };
 export default Disqus;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -41,15 +41,22 @@ interface CommentEmbedProps {
   height?: number;
 }
 
+interface RecommendationsProps {
+  shortname: string;
+  config: DisqusConfig;
+}
+
 declare class CommentCount extends React.Component<CommentCountProps, {}> {}
 declare class CommentEmbed extends React.Component<CommentEmbedProps, {}> {}
 declare class DiscussionEmbed extends React.Component<DiscussionEmbedProps, {}> {}
+declare class Recommendations extends React.Component<RecommendationsProps, {}> {}
 
 declare const Disqus: {
   CommentCount: React.ComponentType<CommentCountProps>;
   CommentEmbed: React.ComponentType<CommentEmbedProps>;
   DiscussionEmbed: React.ComponentType<DiscussionEmbedProps>;
+  Recommendations: React.Component<RecommendationsProps, {}>;
 }
 
-export { CommentCount, CommentEmbed, DiscussionEmbed };
+export { CommentCount, CommentEmbed, DiscussionEmbed, Recommendations };
 export default Disqus;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description  
<!--- Describe your changes in detail -->
I added the missing type definitions for the `Recommendations` component and cleaned up the existing definitions to remove unused definitions and resolve the "Statements not allowed in ambient contexts"(#82)  error.

## Motivation and Context  
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #104 and #82 

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.  
- [x] All new and existing tests passed.  
