### PR TITLE
Add TS compatibility for DiscussionEmbedConfig interface for SSO

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,6 +9,17 @@ interface DisqusConfig {
 interface DiscussionEmbedConfig extends DisqusConfig {
   categoryID?: string;
   language?: string;
+  apiKey?: string;
+  sso?: {
+    name?: string;
+    button?: string;
+    icon?: string;
+    url?: string;
+    logout?: string;
+    profile_url?: string;
+    width?: string;
+    height?: string;
+  };
   // Callbacks
   preData?: (...args: any[]) => any;
   preInit?: (...args: any[]) => any;


### PR DESCRIPTION
## Description  
This change includes typing for the DiscussionEmbedConfig interface to handle SSO properties.

## Motivation and Context  
The DiscussionEmbed component's SSO capabilities should be compatible with TypeScript.  

## How Has This Been Tested?  
Tested on a Disqus-React repo running TS locally.  Also tested with a Disqus publisher's config that is running TS (details in [DSQDEV-2316](https://boomtrain.atlassian.net/browse/DSQDEV-2316)).  Previously, there were TS error messages being generated in the pub's config, but after this change, the error messages were no longer appearing. 

## Screenshots (if appropriate):  

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

## Checklist:  
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have updated the documentation accordingly.   
- [x] All new and existing tests passed.  
